### PR TITLE
Article links

### DIFF
--- a/src/components/ArticleList/index.tsx
+++ b/src/components/ArticleList/index.tsx
@@ -11,7 +11,12 @@ export default function ArticleList({ articles }: Props) {
     <div className="grid auto-rows-max grid-cols-3 gap-4">
       {articles.map((article) => (
         <ArticleCard
-          href="#"
+          href={(() => {
+            const publishDate = DateTime.fromJSDate(article.publishedAt);
+            return `/stories/${publishDate.year}/${publishDate.toFormat(
+              "LL",
+            )}/${publishDate.toFormat("dd")}/${article.slug}`;
+          })()}
           key={article.title}
           topic={article.tags[0]}
           title={article.title}

--- a/src/components/WhatsNewSection/index.tsx
+++ b/src/components/WhatsNewSection/index.tsx
@@ -33,10 +33,6 @@ export default function WhatsNewSection({ articles }: Props) {
             ).toLocaleString(DateTime.DATE_FULL)}
             mediaType={headlineArticle.storyType}
             tag={headlineArticle.tags[0]}
-            // TODO: Incorrect format: month is 0-indexed and not padded, day is not the date
-            // href={`/${headlineArticle.publishedAt.getFullYear()}/${headlineArticle.publishedAt.getMonth()}/${headlineArticle.publishedAt.getDay()}/${
-            //   headlineArticle.slug
-            // }`}
             href={(() => {
               const publishDate = DateTime.fromJSDate(
                 headlineArticle.publishedAt,

--- a/src/components/WhatsNewSection/index.tsx
+++ b/src/components/WhatsNewSection/index.tsx
@@ -34,9 +34,17 @@ export default function WhatsNewSection({ articles }: Props) {
             mediaType={headlineArticle.storyType}
             tag={headlineArticle.tags[0]}
             // TODO: Incorrect format: month is 0-indexed and not padded, day is not the date
-            href={`/${headlineArticle.publishedAt.getFullYear()}/${headlineArticle.publishedAt.getMonth()}/${headlineArticle.publishedAt.getDay()}/${
-              headlineArticle.slug
-            }`}
+            // href={`/${headlineArticle.publishedAt.getFullYear()}/${headlineArticle.publishedAt.getMonth()}/${headlineArticle.publishedAt.getDay()}/${
+            //   headlineArticle.slug
+            // }`}
+            href={(() => {
+              const publishDate = DateTime.fromJSDate(
+                headlineArticle.publishedAt,
+              );
+              return `/stories/${publishDate.year}/${publishDate.toFormat(
+                "LL",
+              )}/${publishDate.toFormat("dd")}/${headlineArticle.slug}`;
+            })()}
           />
         )}
       </div>


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixed incorrect or missing article links from main page cards. The article links now conform to this format:

```
https://<SCIQUEL_URL>/stories/<publish year>/<publish month>/<publish day>/<title slug>
```

The title slug is a reformatted string that is URL friendly for SEO purposes.
For example: Lights. Camera. Action! => lights-camera-action

Currently, the links don't lead to pages (they show 404).

<!-- Please include an issue that this PR closes if it exists. Use one line per issue. -->

## Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

