### PR TITLE
Add Staff Picks section on home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import StaffPicksSection from "@/components/StaffPicksSection";
 import TrendingSection from "@/components/TrendingSection";
 import WhatsNewSection from "@/components/WhatsNewSection";
 import { type GetStoriesResult } from "./api/stories/route";
@@ -11,6 +12,7 @@ export default async function Home() {
       <div className="mx-[10%] my-10 flex flex-col gap-12">
         <WhatsNewSection articles={whatsNewArticles} />
         <TrendingSection articles={whatsNewArticles} />
+        <StaffPicksSection articles={whatsNewArticles} />
       </div>
     </>
   );

--- a/src/components/ArticleCard/ArticleCard.tsx
+++ b/src/components/ArticleCard/ArticleCard.tsx
@@ -1,5 +1,6 @@
 import TopicTag from "@/components/TopicTag";
 import { type StoryTopic } from "@prisma/client";
+import clsx from "clsx";
 import Image from "next/image";
 import Link from "next/link";
 
@@ -11,6 +12,7 @@ interface Props {
   author: string;
   date: string;
   thumbnailUrl: string;
+  preferHorizontal?: boolean;
 }
 
 export default function ArticleCard({
@@ -21,13 +23,16 @@ export default function ArticleCard({
   author,
   date,
   thumbnailUrl,
+  preferHorizontal = false,
 }: Props) {
   return (
     <Link href={href ?? "#"}>
       <div
-        className={`flex h-full min-w-[300px] cursor-pointer flex-col
-        overflow-clip rounded-lg border border-sciquelCardBorder bg-sciquelCardBg
-        transition hover:scale-[1.02]`}
+        className={clsx(
+          `flex h-full min-w-[300px] cursor-pointer overflow-clip rounded-lg border
+          border-sciquelCardBorder bg-sciquelCardBg transition hover:scale-[1.02]`,
+          preferHorizontal ? "flex-row" : "flex-col",
+        )}
       >
         <div className="flex grow flex-col gap-4 p-5">
           {/* Article Card Header */}
@@ -53,7 +58,7 @@ export default function ArticleCard({
             <p>{date}</p>
           </div>
         </div>
-        <div className="relative h-44">
+        <div className={clsx("relative", preferHorizontal ? "w-1/3" : "h-44")}>
           <Image
             src={thumbnailUrl}
             fill={true}

--- a/src/components/ArticleCard/ArticleCard.tsx
+++ b/src/components/ArticleCard/ArticleCard.tsx
@@ -34,7 +34,12 @@ export default function ArticleCard({
           preferHorizontal ? "flex-row" : "flex-col",
         )}
       >
-        <div className="flex grow flex-col gap-4 p-5">
+        <div
+          className={clsx(
+            "flex flex-col gap-4 p-5",
+            preferHorizontal ? "w-2/3" : "grow",
+          )}
+        >
           {/* Article Card Header */}
           <div className="flex w-full flex-row">
             <TopicTag name={topic} />

--- a/src/components/ArticleList/index.tsx
+++ b/src/components/ArticleList/index.tsx
@@ -1,14 +1,24 @@
 import { type GetStoriesResult } from "@/app/api/stories/route";
+import clsx from "clsx";
 import { DateTime } from "luxon";
 import ArticleCard from "../ArticleCard/ArticleCard";
 
 interface Props {
   articles: GetStoriesResult;
+  preferHorizontal?: boolean;
 }
 
-export default function ArticleList({ articles }: Props) {
+export default function ArticleList({
+  articles,
+  preferHorizontal = false,
+}: Props) {
   return (
-    <div className="grid auto-rows-max grid-cols-3 gap-4">
+    <div
+      className={clsx(
+        "grid gap-4",
+        preferHorizontal ? null : "auto-rows-max grid-cols-3",
+      )}
+    >
       {articles.map((article) => (
         <ArticleCard
           href="#"
@@ -28,6 +38,7 @@ export default function ArticleList({ articles }: Props) {
             DateTime.DATE_FULL,
           )}
           thumbnailUrl={article.thumbnailUrl}
+          preferHorizontal={preferHorizontal}
         />
       ))}
     </div>

--- a/src/components/StaffPicksSection/index.tsx
+++ b/src/components/StaffPicksSection/index.tsx
@@ -1,0 +1,21 @@
+import { type GetStoriesResult } from "@/app/api/stories/route";
+import ArticleList from "../ArticleList";
+import HomepageSection from "../HomepageSection";
+
+interface Props {
+  articles: GetStoriesResult;
+}
+
+export default function StaffPicksSection({ articles }: Props) {
+  if (articles.length === 0) {
+    return null;
+  }
+
+  return (
+    <HomepageSection heading="Staff Picks">
+      {articles && (
+        <ArticleList articles={articles.slice(0, 3)} preferHorizontal={true} />
+      )}
+    </HomepageSection>
+  );
+}

--- a/src/components/TrendingSection/index.tsx
+++ b/src/components/TrendingSection/index.tsx
@@ -7,6 +7,10 @@ interface Props {
 }
 
 export default function TrendingSection({ articles }: Props) {
+  if (articles.length === 0) {
+    return null;
+  }
+
   return (
     <HomepageSection heading="Trending">
       {articles && <ArticleList articles={articles.slice(0, 3)} />}


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Add staff picks section on the home page with horizontal article cards. This change creates a new optional property on ArticleCard which allows it to prefer to be horizontal.

## Type of change

<!-- Please delete options that are not relevant. -->

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Not tested for responsiveness.

![image](https://github.com/SciQuel/SciQuel/assets/17174688/49445627-8880-4f37-aa78-6db4d3f29c57)
