### PR TITLE
Add endpoint to record user page views

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "swr": "^2.1.5",
     "tailwindcss": "3.3.2",
     "typescript": "5.0.4",
-    "wavesurfer.js": "^6.6.3"
+    "wavesurfer.js": "^6.6.3",
+    "zod": "^3.21.4"
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^4.0.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -104,3 +104,12 @@ model StoryContent {
 
   createdAt DateTime
 }
+
+model PageView {
+  id String @id @default(auto()) @map("_id") @db.ObjectId
+
+  userId  String @db.ObjectId
+  storyId String @db.ObjectId
+
+  createdAt DateTime @default(now())
+}

--- a/resources/openapi.yaml
+++ b/resources/openapi.yaml
@@ -123,14 +123,16 @@ paths:
         - User
       summary: Record user page view activity
       description: Record the page view activity of a user
-      parameters:
-        - in: query
-          name: story_id
-          schema:
-            type: string
-            example: "647ad74aa9efff3abe83045a"
-          required: true
-          description: ObjectId of the story
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                story_id:
+                  type: string
+                  example: "647ad74aa9efff3abe83045a"
       responses:
         "200":
           description: Successfully record the page view

--- a/resources/openapi.yaml
+++ b/resources/openapi.yaml
@@ -117,6 +117,57 @@ paths:
                     type: string
                     example: Not Found
 
+  /api/user/page_views:
+    post:
+      tags:
+        - User
+      summary: Record user page view activity
+      description: Record the page view activity of a user
+      parameters:
+        - in: query
+          name: story_id
+          schema:
+            type: string
+            example: "647ad74aa9efff3abe83045a"
+          required: true
+          description: ObjectId of the story
+      responses:
+        "200":
+          description: Successfully record the page view
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PageView"
+        "400":
+          description: User specified invalid story id
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: Bad Request
+        "404":
+          description: Specified story id does not exist
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: Story not found
+        "500":
+          description: Failed to insert record into database
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: Failed to create db entry
 components:
   schemas:
     Story:
@@ -242,3 +293,15 @@ components:
         - AUTHOR
         - ILLUSTRATOR
         - ANIMATOR
+    PageView:
+      type: object
+      properties:
+        id:
+          type: string
+        userId:
+          type: string
+        storyId:
+          type: string
+        createdAt:
+          type: string
+          format: date-time

--- a/resources/openapi.yaml
+++ b/resources/openapi.yaml
@@ -133,6 +133,9 @@ paths:
                 story_id:
                   type: string
                   example: "647ad74aa9efff3abe83045a"
+                user_id:
+                  type: string
+                  example: "647ad6fda9efff3abe83044f"
       responses:
         "200":
           description: Successfully record the page view
@@ -141,7 +144,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/PageView"
         "400":
-          description: User specified invalid story id
+          description: Request body is invalid
           content:
             application/json:
               schema:
@@ -151,7 +154,7 @@ paths:
                     type: string
                     example: Bad Request
         "404":
-          description: Specified story id does not exist
+          description: story_id or user_id not found
           content:
             application/json:
               schema:

--- a/src/app/api/user/page_views/route.ts
+++ b/src/app/api/user/page_views/route.ts
@@ -1,0 +1,45 @@
+import prisma from "@/lib/prisma";
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const storyId = searchParams.get("story_id");
+
+  if (storyId === null) {
+    return NextResponse.json({ error: "Bad Request" }, { status: 400 });
+  }
+
+  // validate storyId
+  try {
+    const story = await prisma.story.findUnique({
+      where: {
+        id: storyId,
+      },
+    });
+
+    if (story === null) {
+      return NextResponse.json({ error: "Story not found" }, { status: 404 });
+    }
+  } catch (e) {
+    return NextResponse.json({ error: e }, { status: 400 });
+  }
+
+  //TODO: retrieve userId from session/cookie
+  const userId = "647ad6fda9efff3abe83044f";
+
+  const res = await prisma.pageView.create({
+    data: {
+      userId: userId,
+      storyId: storyId,
+    },
+  });
+
+  if (res === null) {
+    return NextResponse.json(
+      { error: "Failed to create db entry" },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json(res, { status: 200 });
+}

--- a/src/app/api/user/page_views/route.ts
+++ b/src/app/api/user/page_views/route.ts
@@ -12,15 +12,16 @@ const bodySchema = z.object({
 });
 
 export async function POST(req: NextRequest) {
-  const result = bodySchema.safeParse(await req.json());
-  if (!result.success) {
-    return NextResponse.json(result.error, { status: 400 });
-  }
-
-  const { story_id } = result.data;
-
-  // validate story_id
+  let result;
   try {
+    result = bodySchema.safeParse(await req.json());
+    if (!result.success) {
+      return NextResponse.json(result.error, { status: 400 });
+    }
+
+    const { story_id } = result.data;
+
+    // validate story_id
     const story = await prisma.story.findUnique({
       where: {
         id: story_id,
@@ -30,26 +31,35 @@ export async function POST(req: NextRequest) {
     if (story === null) {
       return NextResponse.json({ error: "Story not found" }, { status: 404 });
     }
+
+    //TODO: retrieve user_id from session/cookie
+    const user_id = "647ad6fda9efff3abe83044f";
+
+    const res = await prisma.pageView.create({
+      data: {
+        userId: user_id,
+        storyId: story_id,
+      },
+    });
+
+    if (res === null) {
+      return NextResponse.json(
+        { error: "Failed to create db entry" },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json(res, { status: 200 });
   } catch (e) {
-    return NextResponse.json({ error: e }, { status: 400 });
+    // req.json() throws an error
+    if (!result) {
+      return NextResponse.json(
+        { error: "Invalid request body" },
+        { status: 400 },
+      );
+    }
+
+    // all other errors
+    return NextResponse.json({ error: e }, { status: 500 });
   }
-
-  //TODO: retrieve user_id from session/cookie
-  const user_id = "647ad6fda9efff3abe83044f";
-
-  const res = await prisma.pageView.create({
-    data: {
-      userId: user_id,
-      storyId: story_id,
-    },
-  });
-
-  if (res === null) {
-    return NextResponse.json(
-      { error: "Failed to create db entry" },
-      { status: 500 },
-    );
-  }
-
-  return NextResponse.json(res, { status: 200 });
 }

--- a/src/app/api/user/page_views/route.ts
+++ b/src/app/api/user/page_views/route.ts
@@ -9,6 +9,13 @@ const bodySchema = z.object({
       invalid_type_error: "story_id must be a ObjectId",
     })
     .regex(/^[0-9a-f]{24}$/, { message: "story_id must be a valid ObjectId" }),
+
+  user_id: z
+    .string({
+      required_error: "user_id is required",
+      invalid_type_error: "user_id must be a ObjectId",
+    })
+    .regex(/^[0-9a-f]{24}$/, { message: "user_id must be a valid ObjectId" }),
 });
 
 export async function POST(req: NextRequest) {
@@ -19,7 +26,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json(result.error, { status: 400 });
     }
 
-    const { story_id } = result.data;
+    const { story_id, user_id } = result.data;
 
     // validate story_id
     const story = await prisma.story.findUnique({
@@ -32,8 +39,16 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Story not found" }, { status: 404 });
     }
 
-    //TODO: retrieve user_id from session/cookie
-    const user_id = "647ad6fda9efff3abe83044f";
+    // validate user_id
+    const user = await prisma.user.findUnique({
+      where: {
+        id: user_id,
+      },
+    });
+
+    if (user === null) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
 
     const res = await prisma.pageView.create({
       data: {


### PR DESCRIPTION
# Description

Add schema, endpoint to record user page view activity

~~The endpoint requires future update which needs information on user_id (logged in user, guest, etc), right now I put a placeholder in that field.~~

Modified `user_id` as required body param, require to call `useSession()` at front-end to retrieve `userId` before making API call

Closes #12 

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

url: `http://localhost:3000/api/user/page_views`

| body | Output | Scenario |
| --- | --- | --- |
| `none` | 400 bad request | missing req body |
| `{ "story_id": "abc" }` | 400 bad request | invalid story_id |
| `{ "storyId": "6488c516f5f617c772f6f60e" }` | 400 bad request | missing story_id field |
| `{ "story_id": "6488c516f5f617c772f6f60e" }` | 400 bad request | story_id is valid, missing user_id field |
| `{ "story_id": "6488c516f5f617c772f6f601", "user_id": "647ad6fda9efff3abe83044f" }` | 404 not found | nonexistent story_id |
| `{ "story_id": "6488c516f5f617c772f6f60e", "user_id": "647ad6fda9efff3abe83044f" }` | 200 ok | success request |