### PR TITLE
Add prisma schema for brains

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -113,3 +113,12 @@ model PageView {
 
   createdAt DateTime @default(now())
 }
+
+model Brain {
+  id String @id @default(auto()) @map("_id") @db.ObjectId
+
+  userId  String @db.ObjectId
+  storyId String @db.ObjectId
+
+  createdAt DateTime @default(now())
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -121,4 +121,6 @@ model Brain {
   storyId String @db.ObjectId
 
   createdAt DateTime @default(now())
+
+  @@unique([userId, storyId])
 }

--- a/resources/openapi.yaml
+++ b/resources/openapi.yaml
@@ -173,6 +173,63 @@ paths:
                   error:
                     type: string
                     example: Failed to create db entry
+
+  /api/user/brains:
+    post:
+      tags:
+        - User
+      summary: User brain activity
+      description: User hit brain button at the story
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                story_id:
+                  type: string
+                  example: "647ad74aa9efff3abe83045a"
+                user_id:
+                  type: string
+                  example: "647ad6fda9efff3abe83044f"
+      responses:
+        "200":
+          description: Successfully record the brain activity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Brain"
+        "400":
+          description: Request body is invalid, or try to record duplicate entries
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: Bad Request
+        "404":
+          description: story_id or user_id not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: Story not found
+        "500":
+          description: Failed to insert record into database
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: Failed to create db entry
 components:
   schemas:
     Story:
@@ -299,6 +356,18 @@ components:
         - ILLUSTRATOR
         - ANIMATOR
     PageView:
+      type: object
+      properties:
+        id:
+          type: string
+        userId:
+          type: string
+        storyId:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+    Brain:
       type: object
       properties:
         id:

--- a/src/app/api/user/brains/route.ts
+++ b/src/app/api/user/brains/route.ts
@@ -1,0 +1,91 @@
+import prisma from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+const bodySchema = z.object({
+  story_id: z
+    .string({
+      required_error: "story_id is required",
+      invalid_type_error: "story_id must be a ObjectId",
+    })
+    .regex(/^[0-9a-f]{24}$/, { message: "story_id must be a valid ObjectId" }),
+
+  user_id: z
+    .string({
+      required_error: "user_id is required",
+      invalid_type_error: "user_id must be a ObjectId",
+    })
+    .regex(/^[0-9a-f]{24}$/, { message: "user_id must be a valid ObjectId" }),
+});
+
+export async function POST(req: NextRequest) {
+  let result;
+  try {
+    result = bodySchema.safeParse(await req.json());
+    if (!result.success) {
+      return NextResponse.json(result.error, { status: 400 });
+    }
+
+    const { story_id, user_id } = result.data;
+
+    // validate story_id
+    const story = await prisma.story.findUnique({
+      where: {
+        id: story_id,
+      },
+    });
+
+    if (story === null) {
+      return NextResponse.json({ error: "Story not found" }, { status: 404 });
+    }
+
+    // validate user_id
+    const user = await prisma.user.findUnique({
+      where: {
+        id: user_id,
+      },
+    });
+
+    if (user === null) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    const res = await prisma.brain.create({
+      data: {
+        userId: user_id,
+        storyId: story_id,
+      },
+    });
+
+    if (res === null) {
+      return NextResponse.json(
+        { error: "Failed to create db entry" },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json(res, { status: 200 });
+  } catch (e) {
+    // req.json() throws an error
+    if (!result) {
+      return NextResponse.json(
+        { error: "Invalid request body" },
+        { status: 400 },
+      );
+    }
+
+    // user try to create duplicate entries
+    if (e instanceof Prisma.PrismaClientKnownRequestError) {
+      if (e.code === "P2002") {
+        return NextResponse.json(
+          { error: "story_id and user_id combination already exists" },
+          { status: 400 },
+        );
+      }
+    }
+
+    // all other errors
+    return NextResponse.json({ error: e }, { status: 500 });
+  }
+}


### PR DESCRIPTION
# Description

Add model for brains in prisma schema, create API endpoint

To support `@@unique` in prisma schema, must create compound index manually in mongodb

https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#unique-1
https://www.mongodb.com/docs/manual/core/index-compound/

```shell
> mongo <mongodb_url>
> use sciquel
> db.Brain.createIndex({ userId: 1, storyId: 1}, { unique: true} )
```

Closes #20 

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

Please run `npx prisma generate` on local

# How Has This Been Tested?

url: `http://localhost:3000/api/user/brains`

| Body | Output | Scenario |
| --- | --- | --- |
| `none` | 400 bad request | missing req body |
| `{"story_id": "647ad74aa9efff3abe83045a", "user_id": "647ad6fda9efff3abe83044f"}` | 200 ok | success request |
| `{"story_id": "647ad74aa9efff3abe83045a", "user_id": "647ad6fda9efff3abe83044f"}` | 400 bad request | duplicate entries |
