### PR TITLE
Support filtering stories by topic in backend

### DIFF
--- a/resources/openapi.yaml
+++ b/resources/openapi.yaml
@@ -9,7 +9,7 @@ paths:
       tags:
         - Stories
       summary: Return a list of stories with pagination
-      description: Return a list of stories given a page number and a page size
+      description: Return a list of stories with pagination and optional filter on story topics
       parameters:
         - in: query
           name: page
@@ -34,6 +34,13 @@ paths:
             default: false
           required: false
           description: Return only staff pick stories
+        - in: query
+          name: topic
+          schema:
+            type: string
+            example: "ASTRONOMY"
+          required: false
+          description: Filter stories by topic (non-case sensitive)
       responses:
         "200":
           description: Successfully return a list of stories
@@ -44,7 +51,7 @@ paths:
                 items:
                   $ref: "#/components/schemas/Story"
         "400":
-          description: User requested invalid page or page size
+          description: User requested invalid page or page size or topic
           content:
             application/json:
               schema:


### PR DESCRIPTION
# Description

Add story topic as optional param in story GET endpoint

Closes #35 

## Type of change

<!-- Please delete options that are not relevant. -->

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

| url | output | scenario |
| --- | --- | --- |
| `http://localhost:3000/api/stories?topic=astronomy` | `List of stories matching to astronomy` | `lowercase` |
| `http://localhost:3000/api/stories?topic=BIOLOGY` | `List of stories matching to biology` | `UPPERCASE` |
| `http://localhost:3000/api/stories?topic=medicine` | `[]` | `no matching record` |
| `http://localhost:3000/api/stories?topic=` | `400 bad request` | `did not specify topic` |
| `http://localhost:3000/api/stories?topic=math` | `400 bad request` | `invalid topic` |