### PR TITLE
FIx the shrink crash and Keep font size

### DIFF
--- a/src/components/story-components/StoryCredits.tsx
+++ b/src/components/story-components/StoryCredits.tsx
@@ -4,13 +4,7 @@ import { type GetStoryResult } from "@/app/api/stories/[year]/[month]/[day]/[slu
 import { type StoryTopic } from "@prisma/client";
 import { DateTime } from "luxon";
 import Image from "next/image";
-import {
-  useContext,
-  useEffect,
-  useLayoutEffect,
-  useReducer,
-  useRef,
-} from "react";
+import { useContext, useEffect, useReducer, useRef } from "react";
 import Avatar from "../Avatar";
 import TopicTag from "../TopicTag";
 import { PrintContext } from "./PrintContext";

--- a/src/components/story-components/StoryCredits.tsx
+++ b/src/components/story-components/StoryCredits.tsx
@@ -93,6 +93,8 @@ export default function StoryCredits({ story }: Props) {
     console.log(story);
     if (!isPrintMode) {
       window.addEventListener("resize", handleWindowResize);
+      // Initial calculation on mount
+      dispatchHeaderFont({ type: "window update" });
     } else {
       window.removeEventListener("resize", handleWindowResize);
     }
@@ -101,10 +103,6 @@ export default function StoryCredits({ story }: Props) {
       window.removeEventListener("resize", handleWindowResize);
     };
   }, [isPrintMode]);
-
-  useLayoutEffect(() => {
-    dispatchHeaderFont({ type: "window update" });
-  }, [headerFont]);
 
   function buildContributors() {
     const contributorMap = {
@@ -345,21 +343,19 @@ export default function StoryCredits({ story }: Props) {
           className={`relative m-10 flex min-h-0 w-full flex-col justify-end overflow-hidden `}
         >
           <h1
-            className="mb-0 rounded-t-xl p-8 pb-0 font-customTest text-6xl font-bold sm:text-8xl lg:w-4/5"
+            className="mb-0 rounded-t-xl p-8 pb-0 font-customTest font-bold lg:w-4/5"
             style={{
               color: story.titleColor,
-
-              fontSize: `${Math.max(headerFont, 14)}px`,
-              lineHeight: `${Math.max(headerFont + 3, 14)}px`,
+              fontSize: `${Math.max(headerFont, 18)}px`,
+              lineHeight: `${Math.max(headerFont + 3, 21)}px`,
             }}
           >
             {story.title}
           </h1>
           <h2
-            className=" p-8 pt-0 font-besley text-2xl   lg:w-5/6"
+            className="p-8 pt-0 font-besley lg:w-5/6"
             style={{
               color: story.summaryColor,
-
               fontSize: `${Math.max(headerFont - 33, 14)}px`,
               lineHeight: `${Math.max(headerFont - 28, 14)}px`,
             }}


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Changes description here
Updated font size displaying on the image text and solved window size crash at small width.

<!-- Please include an issue that this PR closes if it exists. Use one line per issue. -->

Closes #[REPLACE WITH ISSUE NUMBER]

## Type of change

<!-- Please delete options that are not relevant. -->

- Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Shrink the window size make sure it is not crash. 
- Font size stays same

**Test Configuration**:

<!-- Please remove sections that are not relevant. -->

- Node.js version:
- Desktop/Mobile:
- OS:
- Browser:
